### PR TITLE
feat: allow suppressing of "Host not alive" messages

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -59,7 +59,9 @@ async function sendPing(host, timeout, retryrate) {
 		}
 		else if (res.alive == false) {
 			self.updateStatus(InstanceStatus.ConnectionFailure);
-			self.log('error', 'Host is not alive.');
+			if (!self.config.noerrlog) {
+				self.log('error', 'Host is not alive.');
+			}
 		}
 		else {
 			self.updateStatus(InstanceStatus.UnknownError);

--- a/src/configFields.js
+++ b/src/configFields.js
@@ -41,6 +41,12 @@ module.exports = {
 				id: 'verbose',
 				label: 'Enable Verbose Logging',
 				default: false
+			},
+			{
+				type: 'checkbox',
+				id: 'noerrlog',
+				label: 'Don\'t log "Host not alive" messages',
+				default: false
 			}
 		]
 	},


### PR DESCRIPTION
Useful if the companion instance is constantly running, but computers that are monitored by ping modules are expected to be offline.
This option allows to prevent the flooding of the companion log with "error" messages when a host is supposed to be offline.